### PR TITLE
Update songticker location

### DIFF
--- a/includes/songticker.php
+++ b/includes/songticker.php
@@ -25,8 +25,8 @@ $context = stream_context_create(
         )
     )
 );
-if ( file_get_contents( 'https://intranet.rabe.ch/songticker/0.9.3/current.xml', false, $context ) ) {
-	$res = file_get_contents( 'https://intranet.rabe.ch/songticker/0.9.3/current.xml', false, $context );
+if ( file_get_contents( 'https://songticker.rabe.ch/songticker/0.9.3/current.xml', false, $context ) ) {
+	$res = file_get_contents( 'https://songticker.rabe.ch/songticker/0.9.3/current.xml', false, $context );
 
 	foreach ( $http_response_header as $header ) {
 		if ( substr( $header, 0, 5 ) == 'ETag:' ) {


### PR DESCRIPTION
The new location points to the version of nowplaying that is being migrated to the current AoIP
stack.

It probably makes sense to keep this on dev for a couple of weeks while I make sure that the new runtime is stable.

On the new platform the `/songticker/0.9.3/current.xml` is the only supported endpoint for now, but I don't think that anyone is using any other endpoints anyway.